### PR TITLE
Use setTimeout function + fix async/await syntax

### DIFF
--- a/imports/api/taskMethods.js
+++ b/imports/api/taskMethods.js
@@ -28,10 +28,7 @@ Meteor.methods({
     // }
 
     //in production use projection to fetch sepcific fields
-    const task = TasksCollection.findOne(
-      { _id: taskId, userId: this.userId },
-      { fields: ["name"] }
-    );
+    const task = TasksCollection.findOne({ _id: taskId, userId: this.userId });
 
     if (!task) {
       throw new Meteor.Error("Access denied.");

--- a/imports/ui/Task.js
+++ b/imports/ui/Task.js
@@ -4,32 +4,37 @@ import { Template } from "meteor/templating";
 
 import "./Task.html";
 
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 Template.task.onCreated(function () {
   this.isUpdateLoading = new ReactiveVar(false);
 });
 
 Template.task.events({
-  async "click .toggle-checked"(event, template) {
+  "click .toggle-checked"(event, template) {
     try {
+      const { data } = Template.instance();
       template.isUpdateLoading.set(true);
-      await sleep(768);
-      await Meteor.call("tasks.setIsChecked", this._id, !this.isChecked);
-      template.isUpdateLoading.set(false);
+
+      Meteor.setTimeout(async function () {
+        await Meteor.callAsync("tasks.setIsChecked", data._id, !data.isChecked);
+        template.isUpdateLoading.set(false);
+      }, 768);
     } catch (error) {
       console.log(error);
     }
   },
-  "click .delete"() {
-    Meteor.call("tasks.remove", this._id);
+
+  async "click .delete"() {
+    try {
+      await Meteor.callAsync("tasks.remove", this._id);
+    } catch (error) {
+      console.log(error);
+    }
   },
 });
 
 Template.task.helpers({
   isUpdateLoading() {
-    return Template.instance().isUpdateLoading.get();
+    const instance = Template.instance();
+    return instance.isUpdateLoading.get();
   },
 });


### PR DESCRIPTION
### Changelog 
 1. Removed the native `setTimout()` function and used `Meteor.setTimeout()`
 2. Modified the event listener based on the comment 
      ```js 
          Template.task.events({
            "click .toggle-checked"(event, template) {
              try {
                const { data } = Template.instance();
                template.isUpdateLoading.set(true);

                Meteor.setTimeout(async function () {
                  await Meteor.callAsync("tasks.setIsChecked", data._id, !data.isChecked);
                  template.isUpdateLoading.set(false);
                }, 768);
             } catch (error) {
              console.log(error);
            }
         } ,
      ```